### PR TITLE
Add benchmarks

### DIFF
--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -143,6 +143,34 @@ namespace Benchmark
             return list;
             
         }
+
+        [Benchmark]
+        public List<MockObject> RxLike()
+        {
+            var list = new List<MockObject>();
+            const int count = 100;
+
+            foreach (var segment in _source.RxTake(count, count))
+            {
+                list.AddRange(segment);
+            }
+            
+            return list;
+        }
+
+        [Benchmark]
+        public List<MockObject> RxLike2()
+        {
+            var list = new List<MockObject>();
+            const int count = 100;
+
+            foreach (var segment in _source.RxSimpleTake(count, count))
+            {
+                list.AddRange(segment);
+            }
+            
+            return list;
+        }
         
     }
 

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -109,6 +109,42 @@ namespace Benchmark
         }
 
         [Benchmark]
+        public List<MockObject> ArrayBuffer()
+        {
+            var list = new List<MockObject>();
+            const int count = 100;
+
+            using (var enumerator = _source.GetEnumerator())
+            {
+                while (enumerator.MoveNext())
+                {
+                    var buffer = new MockObject[count];
+                    
+                    var i = 0;
+                    while (i < count)
+                    {
+                        buffer[i] = enumerator.Current;
+                        if(!enumerator.MoveNext()) break;
+                        i++;
+                    }
+
+                    if (i < count - 1)
+                    {
+                        var newSize = i;
+                        var newArray = new MockObject[newSize];
+                        Array.Copy(buffer, 0, newArray, 0, newSize);
+                        buffer = newArray;
+                    }
+                    
+                    list.AddRange(buffer);
+                }
+            }
+
+            return list;
+            
+        }
+
+        [Benchmark]
         public List<MockObject> RxLike()
         {
             var list = new List<MockObject>();

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -109,42 +109,6 @@ namespace Benchmark
         }
 
         [Benchmark]
-        public List<MockObject> ArrayBuffer()
-        {
-            var list = new List<MockObject>();
-            const int count = 100;
-
-            using (var enumerator = _source.GetEnumerator())
-            {
-                while (enumerator.MoveNext())
-                {
-                    var buffer = new MockObject[count];
-                    
-                    var i = 0;
-                    while (i < count)
-                    {
-                        buffer[i] = enumerator.Current;
-                        if(!enumerator.MoveNext()) break;
-                        i++;
-                    }
-
-                    if (i < count - 1)
-                    {
-                        var newSize = i;
-                        var newArray = new MockObject[newSize];
-                        Array.Copy(buffer, 0, newArray, 0, newSize);
-                        buffer = newArray;
-                    }
-                    
-                    list.AddRange(buffer);
-                }
-            }
-
-            return list;
-            
-        }
-
-        [Benchmark]
         public List<MockObject> RxLike()
         {
             var list = new List<MockObject>();

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -112,32 +112,11 @@ namespace Benchmark
         public List<MockObject> ArrayBuffer()
         {
             var list = new List<MockObject>();
-            const int count = 100;
+//            const int count = 100;
 
-            using (var enumerator = _source.GetEnumerator())
+            foreach (var segment in _source.ArrayBufferSplit(100))
             {
-                while (enumerator.MoveNext())
-                {
-                    var buffer = new MockObject[count];
-                    
-                    var i = 0;
-                    while (i < count)
-                    {
-                        buffer[i] = enumerator.Current;
-                        if(!enumerator.MoveNext()) break;
-                        i++;
-                    }
-
-                    if (i < count - 1)
-                    {
-                        var newSize = i;
-                        var newArray = new MockObject[newSize];
-                        Array.Copy(buffer, 0, newArray, 0, newSize);
-                        buffer = newArray;
-                    }
-                    
-                    list.AddRange(buffer);
-                }
+                list.AddRange(segment);
             }
 
             return list;

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -46,12 +46,12 @@ namespace Benchmark
     {
         private const int IterationCount = 10000;
 
-        private IEnumerable<MockObject> _enum;
+        private IEnumerable<MockObject> _source;
 
         [GlobalSetup]
         public void Setup()
         {
-            _enum = Enumerable.Range(0, IterationCount)
+            _source = Enumerable.Range(0, IterationCount)
                 .Select(v => new MockObject() {Value = v})
                 .ToList();
         }
@@ -60,12 +60,12 @@ namespace Benchmark
         public List<MockObject> LinqSkipTake()
         {
             var list = new List<MockObject>();
-            var segment = _enum.Take(100);
+            var segment = _source.Take(100);
             var cnt = 1;
             while (segment.Any())
             {
                 list.AddRange(segment);
-                segment = _enum.Skip(cnt++ * 100).Take(100);
+                segment = _source.Skip(cnt++ * 100).Take(100);
             }
             return list;
         }
@@ -74,7 +74,7 @@ namespace Benchmark
         public List<MockObject> Split()
         {
             var list = new List<MockObject>();
-            foreach (var segment in _enum.Split(100))
+            foreach (var segment in _source.Split(100))
             {
                 list.AddRange(segment);
             }

--- a/Benchmark/TestSkipImplementations.cs
+++ b/Benchmark/TestSkipImplementations.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Benchmark
+{
+    internal static class TestSkipImplementations
+    {
+        internal static IEnumerable<IEnumerable<T>> RxTake<T>(this IEnumerable<T> source, int count, int skip)
+        {
+            var buffers = new Queue<IList<T>>(Math.Max(1, count - skip) + 1);
+
+            var i = 0;
+            foreach (var item in source)
+            {
+                if (i % skip == 0)
+                {
+                    buffers.Enqueue(new List<T>(count));
+                }
+
+                foreach (var buffer in buffers)
+                {
+                    buffer.Add(item);
+                }
+
+                if (buffers.Count > 0 && buffers.Peek().Count == count)
+                {
+                    yield return buffers.Dequeue();
+                }
+
+                i++;
+            }
+
+            while (buffers.Count > 0)
+            {
+                yield return buffers.Dequeue();
+            }
+        }
+
+        internal static IEnumerable<IEnumerable<T>> RxSimpleTake<T>(this IEnumerable<T> source, int count, int skip)
+        {
+            var buffer = new List<T>(count);
+
+            foreach (var item in source)
+            {
+                buffer.Add(item);
+                if (buffer.Count == count)
+                {
+                    yield return buffer;
+                    buffer = new List<T>(count);
+                }
+            }
+
+            if (buffer.Count > 0)
+            {
+                yield return buffer;
+            }
+        }
+
+    }
+}

--- a/Benchmark/TestSkipImplementations.cs
+++ b/Benchmark/TestSkipImplementations.cs
@@ -5,6 +5,35 @@ namespace Benchmark
 {
     internal static class TestSkipImplementations
     {
+        internal static IEnumerable<IEnumerable<T>> ArrayBufferSplit<T>(this IEnumerable<T> source, int count)
+        {
+            using (var enumerator = source.GetEnumerator())
+            {
+                while (enumerator.MoveNext())
+                {
+                    var buffer = new T[count];
+                    
+                    var i = 0;
+                    while (i < count)
+                    {
+                        buffer[i] = enumerator.Current;
+                        if(!enumerator.MoveNext()) break;
+                        i++;
+                    }
+
+                    if (i < count - 1)
+                    {
+                        var newSize = i;
+                        var newArray = new T[newSize];
+                        Array.Copy(buffer, 0, newArray, 0, newSize);
+                        buffer = newArray;
+                    }
+
+                    yield return buffer;
+                }
+            }
+        }
+        
         internal static IEnumerable<IEnumerable<T>> RxTake<T>(this IEnumerable<T> source, int count, int skip)
         {
             var buffers = new Queue<IList<T>>(Math.Max(1, count - skip) + 1);


### PR DESCRIPTION
https://qiita.com/GlassGrass/items/010e2865cbfd06c71bd6#i-skip--take-%E3%81%9D%E3%81%AE1

このページをもとにいくつかベンチマークを作りました。

僕のPCでの結果：
``` ini

BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=Intel Core i7-6567U CPU 3.30GHz (Skylake), ProcessorCount=4
Frequency=3234378 Hz, Resolution=309.1785 ns, Timer=TSC
.NET Core SDK=2.0.0
  [Host]     : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT DEBUG
  DefaultJob : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT


```
 |       Method |     Mean |     Error |    StdDev |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
 |------------- |---------:|----------:|----------:|---------:|--------:|--------:|----------:|
 |        Split | 207.8 us |  4.023 us |  4.305 us |  96.6797 | 64.2090 | 32.2266 | 280.03 KB |
 |  ArrayBuffer | 197.1 us |  3.381 us |  3.163 us |  96.6797 | 64.2090 | 32.2266 | 279.98 KB |
 |      RxLike2 | 209.5 us |  3.622 us |  3.388 us |  96.6797 | 64.2090 | 32.2266 | 284.77 KB |
 |   ListBuffer | 243.6 us |  3.155 us |  2.635 us | 161.1328 | 63.9648 | 32.2266 | 412.27 KB |
 | LinqSkipTake | 279.3 us |  5.777 us | 15.320 us |  83.0078 | 41.5039 | 41.5039 | 270.42 KB |
 |       RxLike | 527.5 us | 10.839 us | 20.090 us |  96.6797 | 63.4766 | 32.2266 | 284.03 KB |
